### PR TITLE
fix $request->path在单元测试中拿不到正确值，导致MineFormRequest验证失败

### DIFF
--- a/src/MineApiFormRequest.php
+++ b/src/MineApiFormRequest.php
@@ -51,12 +51,22 @@ class MineApiFormRequest extends FormRequest
      */
     protected function getOperation(): ?string
     {
-        $path = explode('/', $this->path());
+        $path = explode('/', $this->getFixPath());
         do {
             $operation = array_pop($path);
         } while (is_numeric($operation));
 
         return $operation;
+    }
+
+    /**
+     * request->path在单元测试中拿不到，导致MineFormRequest验证失败
+     * 取uri中的path, fix
+     * @return string|null
+     */
+    protected function getFixPath(): string
+    {
+        return ltrim($this->getUri()->getPath(), '/');
     }
 
 

--- a/src/MineFormRequest.php
+++ b/src/MineFormRequest.php
@@ -50,7 +50,7 @@ class MineFormRequest extends FormRequest
      */
     protected function getOperation(): ?string
     {
-        $path = explode('/', $this->path());
+        $path = explode('/', $this->getFixPath());
         do {
             $operation = array_pop($path);
         } while (is_numeric($operation));
@@ -58,5 +58,14 @@ class MineFormRequest extends FormRequest
         return $operation;
     }
 
+    /**
+     * request->path在单元测试中拿不到，导致MineFormRequest验证失败
+     * 取uri中的path, fix
+     * @return string|null
+     */
+    protected function getFixPath(): string
+    {
+        return ltrim($this->getUri()->getPath(), '/');
+    }
 
 }


### PR DESCRIPTION
fix