### PR TITLE
fix:修复MapperGenerator参数判定

### DIFF
--- a/src/Generator/Traits/MapperGeneratorTraits.php
+++ b/src/Generator/Traits/MapperGeneratorTraits.php
@@ -48,7 +48,7 @@ trait MapperGeneratorTraits
             return <<<php
 
         // {$comment}
-        if (blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
             \$query->where('{$name}', 'like', '%'.\$params['{$name}'].'%');
         }
 
@@ -59,7 +59,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (blank(\$params['{$name}']) && is_array(\$params['{$name}']) && count(\$params['{$name}']) == 2) {
+        if (isset(\$params['{$name}']) && blank(\$params['{$name}']) && is_array(\$params['{$name}']) && count(\$params['{$name}']) == 2) {
             \$query->whereBetween(
                 '{$name}',
                 [ \$params['{$name}'][0], \$params['{$name}'][1] ]
@@ -73,7 +73,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
             \$query->whereIn('{$name}', \$params['{$name}']);
         }
 
@@ -84,7 +84,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
             \$query->whereNotIn('{$name}', \$params['{$name}']);
         }
 
@@ -94,7 +94,7 @@ php;
         return <<<php
 
         // {$comment}
-        if (blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
             \$query->where('{$name}', '{$mark}', \$params['{$name}']);
         }
 

--- a/src/Generator/Traits/MapperGeneratorTraits.php
+++ b/src/Generator/Traits/MapperGeneratorTraits.php
@@ -48,7 +48,7 @@ trait MapperGeneratorTraits
             return <<<php
 
         // {$comment}
-        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && !blank(\$params['{$name}'])) {
             \$query->where('{$name}', 'like', '%'.\$params['{$name}'].'%');
         }
 
@@ -59,7 +59,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (isset(\$params['{$name}']) && blank(\$params['{$name}']) && is_array(\$params['{$name}']) && count(\$params['{$name}']) == 2) {
+        if (isset(\$params['{$name}']) && !blank(\$params['{$name}']) && is_array(\$params['{$name}']) && count(\$params['{$name}']) == 2) {
             \$query->whereBetween(
                 '{$name}',
                 [ \$params['{$name}'][0], \$params['{$name}'][1] ]
@@ -73,7 +73,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && !blank(\$params['{$name}'])) {
             \$query->whereIn('{$name}', \$params['{$name}']);
         }
 
@@ -84,7 +84,7 @@ php;
             return <<<php
 
         // {$comment}
-        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && !blank(\$params['{$name}'])) {
             \$query->whereNotIn('{$name}', \$params['{$name}']);
         }
 
@@ -94,7 +94,7 @@ php;
         return <<<php
 
         // {$comment}
-        if (isset(\$params['{$name}']) && blank(\$params['{$name}'])) {
+        if (isset(\$params['{$name}']) && !blank(\$params['{$name}'])) {
             \$query->where('{$name}', '{$mark}', \$params['{$name}']);
         }
 


### PR DESCRIPTION
当使用代码生成器生成代码后，运行列表不存在此字段时，查询保存 而 默认请求列表时 并不带此参数 
![image](https://github.com/mineadmin/mine/assets/11536014/6e44dcdb-6653-4971-825f-766d358f085e)
